### PR TITLE
Support for Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,23 @@ language: php
 
 sudo: false
 
-matrix:
-  fast_finish: true
-
-before_script:
-  - composer self-update
-  - composer install --prefer-source
-
 php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
+
+matrix:
+  include:
+    - php: 5.5
+      env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable"
+    - php: 7.0
+      env: COMPOSER_REQUIRE="symfony/process:^2.0"
+    - php: 7.0
+      env: COMPOSER_REQUIRE="symfony/process:^3.0"
+
+before_script:
+  - composer self-update
+  - if [ -n "$COMPOSER_REQUIRE" ]; then composer require --no-update $COMPOSER_REQUIRE; fi
+  - composer update $COMPOSER_OPTIONS

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         "evenement/evenement" : "^2.0|^1.0",
         "monolog/monolog"     : "^1.3",
         "psr/log"             : "^1.0",
-        "symfony/process"     : "^2.0|^3.0"
+        "symfony/process"     : "^2.3|^3.0|^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit"     : "^4.0"
+        "phpunit/phpunit"     : "^4.0|^5.0"
     },
     "autoload": {
         "psr-0": {

--- a/tests/Alchemy/Tests/BinaryDriver/LTSProcessBuilder.php
+++ b/tests/Alchemy/Tests/BinaryDriver/LTSProcessBuilder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Alchemy\Tests\BinaryDriver;
+
+use Alchemy\BinaryDriver\ProcessBuilderFactory;
+use LogicException;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+class LTSProcessBuilder extends ProcessBuilder
+{
+    private $arguments;
+    private $prefix;
+    private $timeout;
+
+    public function __construct(array $arguments = array())
+    {
+        $this->arguments = $arguments;
+        parent::__construct($arguments);
+    }
+
+    public function setArguments(array $arguments)
+    {
+        $this->arguments = $arguments;
+
+        return $this;
+    }
+
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    public function setTimeout($timeout)
+    {
+        $this->timeout = $timeout;
+
+        return $this;
+    }
+
+    public function getProcess()
+    {
+        if (!$this->prefix && !count($this->arguments)) {
+            throw new LogicException('You must add() command arguments before calling getProcess().');
+        }
+
+        $args = $this->prefix ? array_merge(array($this->prefix), $this->arguments) : $this->arguments;
+        $script = implode(' ', array_map('escapeshellarg', $args));
+
+        return new Process($script, null, null, null, $this->timeout);
+    }
+}

--- a/tests/Alchemy/Tests/BinaryDriver/LTSProcessBuilderFactoryTest.php
+++ b/tests/Alchemy/Tests/BinaryDriver/LTSProcessBuilderFactoryTest.php
@@ -2,12 +2,20 @@
 
 namespace Alchemy\Tests\BinaryDriver;
 
-use Symfony\Component\Process\ProcessBuilder;
 use Alchemy\BinaryDriver\ProcessBuilderFactory;
-use Symfony\Component\Process\Process;
 
 class LTSProcessBuilderFactoryTest extends AbstractProcessBuilderFactoryTest
 {
+    public function setUp()
+    {
+        if (!class_exists('Symfony\Component\Process\ProcessBuilder')) {
+            $this->markTestSkipped('ProcessBuilder is not available.');
+            return;
+        }
+
+        parent::setUp();
+    }
+
     protected function getProcessBuilderFactory($binary)
     {
         $factory = new ProcessBuilderFactory($binary);
@@ -16,51 +24,5 @@ class LTSProcessBuilderFactoryTest extends AbstractProcessBuilderFactoryTest
         $factory->useBinary($binary);
 
         return $factory;
-    }
-}
-
-class LTSProcessBuilder extends ProcessBuilder
-{
-    private $arguments;
-    private $prefix;
-    private $timeout;
-
-    public function __construct(array $arguments = array())
-    {
-        $this->arguments = $arguments;
-        parent::__construct($arguments);
-    }
-
-    public function setArguments(array $arguments)
-    {
-        $this->arguments = $arguments;
-
-        return $this;
-    }
-
-    public function setPrefix($prefix)
-    {
-        $this->prefix = $prefix;
-
-        return $this;
-    }
-
-    public function setTimeout($timeout)
-    {
-        $this->timeout = $timeout;
-
-        return $this;
-    }
-
-    public function getProcess()
-    {
-        if (!$this->prefix && !count($this->arguments)) {
-            throw new LogicException('You must add() command arguments before calling getProcess().');
-        }
-
-        $args = $this->prefix ? array_merge(array($this->prefix), $this->arguments) : $this->arguments;
-        $script = implode(' ', array_map('escapeshellarg', $args));
-
-        return new Process($script, null, null, null, $this->timeout);
     }
 }


### PR DESCRIPTION
This patch adds support for Symfony 4 components. In addition, the build matrix has been extended to ensure the lower version bounds of the requirements are correct.